### PR TITLE
Add CONTRIBUTING guidelines for small, focused PRs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,11 @@
+## Contributing
+
+- Keep PRs small and focused (one script or feature per PR).
+- Prefer argparse for new CLI features; validate user input.
+- Preserve existing behavior unless you clearly improve UX.
+- Include a short description and test steps in your PR body.
+- Use informative commit messages and snake_case in Python.
+
+### Local test checklist
+- python3 -m py_compile path/to/script.py
+- Run the script (interactive or with flags) and verify outputs.


### PR DESCRIPTION
Adds CONTRIBUTING.md outlining guidelines for small, focused PRs, argparse usage, validation, and a brief local test checklist.